### PR TITLE
obs, bbs 라디오 링크 수정 #3

### DIFF
--- a/functions/stream/url/bbs.js
+++ b/functions/stream/url/bbs.js
@@ -1,6 +1,6 @@
 export const bbsUrls = [
     /* BBS 불교방송 */
-    { name: "BBS 서울불교방송", city: null, streamUrl: "https://bbslive.clouducs.com/bbsradio-live/livestream/playlist.m3u8" },  // default
+    { name: "BBS 서울불교방송", city: null, streamUrl: "https://bbslive.clouducs.com/bbsradio-mlive/radio.stream/playlist.m3u8" },  // default
     { name: "BBS 부산불교방송", city: "busan", streamUrl: "http://live.cdn.smilecdn.com:1935/bbsfm_live/live.sdp/playlist.m3u8" },
     { name: "BBS 대구불교방송", city: "daegu", streamUrl: "https://bbslive.goldenday.kr:446/hls/dgbbs.m3u8" },
     { name: "BBS 광주불교방송", city: "gwangju", streamUrl: "http://live.cdn.smilecdn.com:1935/kjbbs1_live/live/playlist.m3u8" },

--- a/functions/stream/url/common.js
+++ b/functions/stream/url/common.js
@@ -8,7 +8,7 @@ export const commonUrls = [
       : "https://stream.ifm.kr/live/aod1/playlist.m3u8";
       return url;
     } catch (e) { return null; }} },  // default
-    { name: "OBS 라디오", station: "obs", streamUrl: "https://vod3.obs.co.kr:444/live/obsstream1/radio.stream/playlist.m3u8" },
+    { name: "OBS 라디오", station: "obs", streamUrl: "https://vod.obs.co.kr:444/live/obsstream1/radio.stream/playlist.m3u8" },
     { name: "국방FM", station: "kookbang", streamUrl: "https://mediaworks.dema.mil.kr/live_edge/audio.sdp/playlist.m3u8" },
     { name: "Arirang Radio", station: "arirang", streamUrl: "https://amdlive-ch03-ctnd-com.akamaized.net/arirang_3ch/smil:arirang_3ch.smil/playlist.m3u8"},
     { name: "부산영어방송", station: "befm", streamUrl: "https://live.cdn.smilecdn.com/befm905_live/live/playlist.m3u8"},


### PR DESCRIPTION
This pull request updates streaming URLs for two radio stations to ensure continued service by switching to their latest endpoints.

Streaming URL updates:

* Updated the stream URL for "BBS 서울불교방송" in `bbsUrls` to use the new path (`bbsradio-mlive/radio.stream`) in `functions/stream/url/bbs.js`.
* Updated the stream URL for "OBS 라디오" in `commonUrls` to use the new domain (`vod.obs.co.kr`) in `functions/stream/url/common.js`.

Reference: https://github.com/BSofDeath/radio.bsod.kr/issues/3